### PR TITLE
Create user tracker only when no failing

### DIFF
--- a/include/openni2_camera/openni2_device.h
+++ b/include/openni2_camera/openni2_device.h
@@ -107,7 +107,7 @@ public:
   void startColorStream();
   void startDepthStream();
   void startHandTracker();
-  void startUserTracker();
+  bool startUserTracker();
 
   void stopAllStreams();
 

--- a/include/openni2_camera/openni2_device_manager.h
+++ b/include/openni2_camera/openni2_device_manager.h
@@ -62,6 +62,7 @@ public:
   boost::shared_ptr<OpenNI2Device> getDevice(const std::string& device_URI);
 
   std::string getSerial(const std::string& device_URI) const;
+  std::string getFirmwareVersion(const std::string& Uri) const;
 
 protected:
   boost::shared_ptr<OpenNI2DeviceListener> device_listener_;

--- a/src/openni2_device.cpp
+++ b/src/openni2_device.cpp
@@ -67,13 +67,16 @@ OpenNI2Device::OpenNI2Device(const std::string& device_URI) throw (OpenNI2Except
   if (rc != openni::STATUS_OK)
     THROW_OPENNI_EXCEPTION("Initialize failed\n%s\n", openni::OpenNI::getExtendedError());
 
-  std::cout << std::endl << "NiTE2 Initialization" << std::endl << std::endl;
+  std::cout << std::endl << "NiTE2 Initialization" << std::endl;
   //Initialize NiTE2
   nite::Status niteRc = nite::NiTE::initialize();
   if (niteRc != nite::STATUS_OK)
     std::cout << "NiTE2 initialization failed. Hand and user tracking won't be available" << std::endl;
   else
+  {
     has_nite_ = true;
+    std::cout << "NiTE2 initialized" << std::endl;
+  }
 
   openni_device_ = boost::make_shared<openni::Device>();
 
@@ -356,6 +359,11 @@ void OpenNI2Device::startUserTracker()
   {
     user_tracker_->addNewFrameListener(user_tracker_frame_listener_.get());
     user_tracker_started_ = true;
+  }
+  else
+  {
+    THROW_OPENNI_EXCEPTION("Unable to create an instance of User Tracker");
+    std::cout << "ERRORRRRRR" << std::endl << std::endl;
   }
 }
 

--- a/src/openni2_device.cpp
+++ b/src/openni2_device.cpp
@@ -855,10 +855,14 @@ boost::shared_ptr<nite::HandTracker> OpenNI2Device::getHandTracker() const throw
 boost::shared_ptr<nite::UserTracker> OpenNI2Device::getUserTracker() const throw (OpenNI2Exception)
 {
   if ( !has_nite_ )
+  {
+    std::cout << "\tOpenNI2Device::getUserTracker: no NITE detected" << std::endl;
     THROW_OPENNI_EXCEPTION("Not creating user tracking because NiTE2 could not be initialized");
+  }
 
   if ( openni_device_.get() == NULL )
   {
+    std::cout << "\tOpenNI2Device::getUserTracker: device not opened" << std::endl;
     THROW_OPENNI_EXCEPTION("Not creating user tracking because device has not been initialized");
   }
 
@@ -868,10 +872,13 @@ boost::shared_ptr<nite::UserTracker> OpenNI2Device::getUserTracker() const throw
   {
     stream->setMirroringEnabled(false);
   }
+  else
+      std::cout << "\tOpenNI2Device::getUserTracker: no stream" << std::endl;
   user_tracker_ = boost::make_shared<nite::UserTracker>();
   nite::Status niteRc = user_tracker_->create(openni_device_.get());
   if (niteRc != nite::STATUS_OK)
   {
+    std::cout << "\tOpenNI2Device::getUserTracker: could not create user tracker (error code: " << niteRc << ")" << std::endl;
     THROW_OPENNI_EXCEPTION("Couldn't create user tracker");
   }
 

--- a/src/openni2_device_manager.cpp
+++ b/src/openni2_device_manager.cpp
@@ -215,6 +215,36 @@ std::size_t OpenNI2DeviceManager::getNumOfConnectedDevices() const
   return device_listener_->getNumOfConnectedDevices();
 }
 
+std::string OpenNI2DeviceManager::getFirmwareVersion(const std::string& Uri) const
+{
+  openni::Device openni_device;
+  std::string ret;
+
+  // we need to open the device to query the serial number
+  if (Uri.length() > 0 && openni_device.open(Uri.c_str()) == openni::STATUS_OK)
+  {
+    int fw_ver_len = 100;
+    char fw_version[fw_ver_len];
+
+    openni::Status rc = openni_device.getProperty(openni::DEVICE_PROPERTY_FIRMWARE_VERSION, fw_version, &fw_ver_len);
+    if (rc == openni::STATUS_OK)
+    {
+      ret = fw_version;
+    } 
+    else
+    {
+      THROW_OPENNI_EXCEPTION("Firwmare version query failed: %s", openni::OpenNI::getExtendedError());
+    }
+    // close the device again
+    openni_device.close();
+  }
+  else
+  {
+    THROW_OPENNI_EXCEPTION("Device open failed: %s", openni::OpenNI::getExtendedError());
+  }
+  return ret;
+}
+
 std::string OpenNI2DeviceManager::getSerial(const std::string& Uri) const
 {
   openni::Device openni_device;

--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -167,8 +167,16 @@ void OpenNI2Driver::advertiseROSTopics()
     device_->setUserTrackerFrameCallback(boost::bind(&OpenNI2Driver::newUserTrackerFrameCallback, this, _1, _2));
 
     ROS_INFO("Starting user tracker...");
-    device_->startUserTracker();
-    ROS_INFO("User tracker started");   
+    if ( !device_->startUserTracker() )
+    {
+        ROS_ERROR("User tracker could not be started");
+        pub_users_.shutdown();
+        pub_user_map_.shutdown();
+    }
+    else
+    {
+        ROS_INFO("User tracker started");
+    }
   }
 
   ////////// CAMERA INFO MANAGER

--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -166,8 +166,9 @@ void OpenNI2Driver::advertiseROSTopics()
 
     device_->setUserTrackerFrameCallback(boost::bind(&OpenNI2Driver::newUserTrackerFrameCallback, this, _1, _2));
 
-    ROS_INFO("Starting user tracker.");
+    ROS_INFO("Starting user tracker...");
     device_->startUserTracker();
+    ROS_INFO("User tracker started");   
   }
 
   ////////// CAMERA INFO MANAGER
@@ -1187,6 +1188,8 @@ void OpenNI2Driver::initDevice()
     {
       std::string device_URI = resolveDeviceURI(device_id_);
       device_ = device_manager_->getDevice(device_URI);
+      ROS_INFO_STREAM("Serial number   : " << device_manager_->getSerial(device_URI));
+      ROS_INFO_STREAM("Firmware version: " << device_manager_->getFirmwareVersion(device_URI));
     }
     catch (const OpenNI2Exception& exception)
     {


### PR DESCRIPTION
This check is necessary as in recent versions of Orbbec Astra S the driver is not able to create a UserTracker and the whole node crashes.